### PR TITLE
Apply a class to <em>'s containing Japanese characters

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -15,6 +15,9 @@ require('./src/css/reset.css');
 require('./src/prism-styles');
 require('./src/css/algolia.css');
 
+// Import Japanese style fix CSS
+require('./src/css/ja-fix.css');
+
 // Expose React and ReactDOM as globals for console playground
 window.React = React;
 window.ReactDOM = ReactDOM;

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -55,6 +55,7 @@ module.exports = {
               maxWidth: 840,
             },
           },
+          'gatsby-remark-japanese-fix',
           'gatsby-remark-header-custom-ids',
           {
             resolve: 'gatsby-remark-code-repls',

--- a/plugins/gatsby-remark-japanese-fix/index.js
+++ b/plugins/gatsby-remark-japanese-fix/index.js
@@ -1,21 +1,22 @@
 const toString = require('mdast-util-to-string');
 const visit = require('unist-util-visit');
 
-const hasJapanese = str => {
-  // Detects katakana, hiragana, iteration mark (々), and CJK unified ideographs
+const hasJapaneseCharacter = str => {
+  // Detects katakana, hiragana, iteration marks, and CJK unified ideographs
   return /[\u30a0-\u30ff\u3040-\u309f\u3005-\u3006\u4e00-\u9fea。、]/.test(str);
 };
 
 /**
- * Iterates over emphasises (<em>'s) within the AST created by Markdown docs.
- * Applies 'em-ja' class only when it contains some Japanese character,
- * so that it can be displayed differently.
+ * Iterates over emphases (<em>'s) within the AST created by remark.
+ * Applies 'em-ja' class only when it contains a Japanese character,
+ * so that it can be displayed with a different style.
  */
 
 module.exports = ({markdownAST}, options) => {
   visit(markdownAST, 'emphasis', node => {
     const nodeStr = toString(node);
-    if (hasJapanese(nodeStr)) {
+    if (hasJapaneseCharacter(nodeStr)) {
+      // Patch AST
       node.data = node.data || {};
       node.data.hProperties = node.data.hProperties || {};
       node.data.hProperties.class = 'em-ja';

--- a/plugins/gatsby-remark-japanese-fix/index.js
+++ b/plugins/gatsby-remark-japanese-fix/index.js
@@ -11,7 +11,7 @@ const hasJapanese = str => {
  * so that it can be displayed differently.
  */
 
-module.exports = ({ markdownAST }, options) => {
+module.exports = ({markdownAST}, options) => {
   visit(markdownAST, 'emphasis', node => {
     const nodeStr = toString(node);
     if (hasJapanese(nodeStr)) {

--- a/plugins/gatsby-remark-japanese-fix/index.js
+++ b/plugins/gatsby-remark-japanese-fix/index.js
@@ -1,0 +1,24 @@
+const toString = require('mdast-util-to-string');
+const visit = require('unist-util-visit');
+
+const hasJapanese = str => {
+  return /[\u30a0-\u30ff\u3040-\u309f\u3005-\u3006\u30e0-\u9fcf。、]/.test(str);
+};
+
+/**
+ * Iterates over emphasises (<em>'s) within the AST created by Markdown docs.
+ * Applies 'em-ja' class only when it contains some Japanese character,
+ * so that it can be displayed differently.
+ */
+
+module.exports = ({ markdownAST }, options) => {
+  visit(markdownAST, 'emphasis', node => {
+    const nodeStr = toString(node);
+    if (hasJapanese(nodeStr)) {
+      node.data = node.data || {};
+      node.data.hProperties = node.data.hProperties || {};
+      node.data.hProperties.class = 'em-ja';
+    }
+  });
+  return markdownAST;
+};

--- a/plugins/gatsby-remark-japanese-fix/index.js
+++ b/plugins/gatsby-remark-japanese-fix/index.js
@@ -2,7 +2,8 @@ const toString = require('mdast-util-to-string');
 const visit = require('unist-util-visit');
 
 const hasJapanese = str => {
-  return /[\u30a0-\u30ff\u3040-\u309f\u3005-\u3006\u30e0-\u9fcf。、]/.test(str);
+  // Detects katakana, hiragana, iteration mark (々), and CJK unified ideographs
+  return /[\u30a0-\u30ff\u3040-\u309f\u3005-\u3006\u4e00-\u9fea。、]/.test(str);
 };
 
 /**

--- a/plugins/gatsby-remark-japanese-fix/package.json
+++ b/plugins/gatsby-remark-japanese-fix/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "gatsby-remark-japanese-fix",
+  "version": "0.0.1"
+}

--- a/src/css/ja-fix.css
+++ b/src/css/ja-fix.css
@@ -1,0 +1,4 @@
+.em-ja {
+  font-weight: bolder;
+  font-style: normal;
+}


### PR DESCRIPTION
This fixes #22 .

- Added a Gatsby custom plugin that iterates over the AST and add `em-ja` class to `<em>`'s that contain any Japanese character.
- Added a CSS rule to render `.em-ja` with **bold** instead of *italic*.

---

環境によって日本語で em が正しくレンダリングされない問題を修正します。em で強調されている文字列に日本語文字が含まれている場合（例: `*あああ*`）、問答無用で太字にします。

もし `yarn dev` で太字が反映されない場合は `yarn reset` でキャッシュを削除してみてください。