### PR TITLE
Unify `category` format in  frontmatter

### DIFF
--- a/content/docs/addons-shallow-renderer.md
+++ b/content/docs/addons-shallow-renderer.md
@@ -3,7 +3,7 @@ id: shallow-renderer
 title: Shallow Renderer
 permalink: docs/shallow-renderer.html
 layout: docs
-category: リファレンス
+category: Reference
 ---
 
 **インポート**

--- a/content/docs/reference-glossary.md
+++ b/content/docs/reference-glossary.md
@@ -2,7 +2,7 @@
 id: glossary
 title: React 用語集
 layout: docs
-category: リファレンス
+category: Reference
 permalink: docs/glossary.html
 
 ---


### PR DESCRIPTION
Related #4
Very tiny PR.

### Background
I wondered if `category`' s value (such as `Reference` or `Add-ons`) in frontmatter should be translated.
I found that members had also mentioned in #21 . 
But it remains unclear if they should be translated or not.
I studied how they are used in this repo.

### Conclusion
The values of `category` are *not* used anywhere in reactjs.org at least for now.
Therefore, whichever is ok currently.
It will be better not to translate them and leave them as they are, considering they might be used for unknown purposes in the future.

I checked
- no strings of `category` in `public` dir after building sites
- no GraphQL query containing `category`
- `Node` type  in `src/types.js` does not have `category`
- In `gatsby` dir, only `redirect_from` and `permalink` are used as frontmatter value
- Backend seach engine is `docsearch`, which use only html files as data source