### PR TITLE
Translate link text in top page

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -133,7 +133,7 @@ class Home extends Component {
                         fontSize: 30,
                       },
                     }}>
-                    A JavaScript library for building user interfaces
+                    ユーザインターフェース構築のための JavaScript ライブラリ
                   </p>
                   <Flex
                     valign="center"
@@ -148,12 +148,12 @@ class Home extends Component {
                       <ButtonLink
                         to="/docs/getting-started.html"
                         type="primary">
-                        Get Started
+                        スタートガイド
                       </ButtonLink>
                     </CtaItem>
                     <CtaItem>
                       <ButtonLink to="/tutorial/tutorial.html" type="secondary">
-                        Take the Tutorial
+                        チュートリアルを見る
                       </ButtonLink>
                     </CtaItem>
                   </Flex>
@@ -285,12 +285,12 @@ class Home extends Component {
               <Flex valign="center">
                 <CtaItem>
                   <ButtonLink to="/docs/getting-started.html" type="primary">
-                    Get Started
+                    スタートガイド
                   </ButtonLink>
                 </CtaItem>
                 <CtaItem>
                   <ButtonLink to="/tutorial/tutorial.html" type="secondary">
-                    Take the Tutorial
+                    チュートリアルを見る
                   </ButtonLink>
                 </CtaItem>
               </Flex>


### PR DESCRIPTION
Part of #145

This PR contains translations for some text in the React top page.

"Getting Started" は某所で調べると「スタートガイド」が多かったのでそうしてみました