### PR TITLE
fix spelling variants

### DIFF
--- a/content/docs/code-splitting.md
+++ b/content/docs/code-splitting.md
@@ -180,9 +180,9 @@ function MyComponent() {
 }
 ```
 
-### Error boundaries {#error-boundaries}
+### Error Boundary {#error-boundaries}
 
-もし他のモジュールがロードに失敗した場合（例えば、ネットワークの障害など）、エラーが発生します。その際には [Error Boundaries](/docs/error-boundaries.html) を使用することによってこれらのエラーをハンドリングし、エラーの回復やユーザ体験の向上に繋げることができます。Error Boundary を作成したら、遅延コンポーネントより上位のあらゆる場所で使用でき、ネットワークエラーが発生した際にエラー内容を表示することができます。
+もし他のモジュールがロードに失敗した場合（例えば、ネットワークの障害など）、エラーが発生します。その際には [error boundary](/docs/error-boundaries.html) を使用することによってこれらのエラーをハンドリングし、エラーの回復やユーザ体験の向上に繋げることができます。error boundary を作成したら、遅延コンポーネントより上位のあらゆる場所で使用でき、ネットワークエラーが発生した際にエラー内容を表示することができます。
 
 ```js
 import MyErrorBoundary from './MyErrorBoundary';

--- a/content/docs/nav.yml
+++ b/content/docs/nav.yml
@@ -44,7 +44,7 @@
     - id: context
       title: コンテクスト
     - id: error-boundaries
-      title: Error Boundaries
+      title: Error Boundary
     - id: forwarding-refs
       title: ref のフォワーディング
     - id: fragments

--- a/content/docs/reference-react-component.md
+++ b/content/docs/reference-react-component.md
@@ -313,19 +313,19 @@ getSnapshotBeforeUpdate(prevProps, prevState)
 
 * * *
 
-### error boundaries {#error-boundaries}
+### error boundary {#error-boundaries}
 
-[error boundaries](/docs/error-boundaries.html) は、子コンポーネントツリーのどこかで JavaScript エラーを捕捉し、それらのエラーを記録し、クラッシュしたコンポーネントツリーの代わりにフォールバック UI を表示する React コンポーネントです。error boundaries は、その下のツリー全体のレンダー中、ライフサイクルメソッド内、およびコンストラクタ内で発生したエラーを捕捉します。
+[error boundary](/docs/error-boundaries.html) は、子コンポーネントツリーのどこかで JavaScript エラーを捕捉し、それらのエラーを記録し、クラッシュしたコンポーネントツリーの代わりにフォールバック UI を表示する React コンポーネントです。error boundary は、その下のツリー全体のレンダー中、ライフサイクルメソッド内、およびコンストラクタ内で発生したエラーを捕捉します。
 
-クラスコンポーネントは、ライフサイクルメソッド `static getDerivedStateFromError()` または `componentDidCatch()` のいずれか（または両方）を定義すると、error boundaries になります。これらのライフサイクルから state を更新すると、下のツリーで発生した未処理の JavaScript エラーを捕捉してフォールバック UI を表示できます。
+クラスコンポーネントは、ライフサイクルメソッド `static getDerivedStateFromError()` または `componentDidCatch()` のいずれか（または両方）を定義すると、error boundary になります。これらのライフサイクルから state を更新すると、下のツリーで発生した未処理の JavaScript エラーを捕捉してフォールバック UI を表示できます。
 
-error boundaries は予期しない例外からの回復のためだけに使用してください。**それらを制御フローに使用しないでください**。
+error boundary は予期しない例外からの回復のためだけに使用してください。**それらを制御フローに使用しないでください**。
 
 詳細については、[*React 16 のエラーハンドリング*](/blog/2017/07/26/error-handling-in-react-16.html)を参照してください。
 
 > 補足
 > 
-> error boundaries は、ツリー内でその**下**にあるコンポーネント内のエラーのみを捕捉します。error boundaries はそれ自体の中でエラーを捉えることはできません。
+> error boundary は、ツリー内でその**下**にあるコンポーネント内のエラーのみを捕捉します。error boundary はそれ自体の中でエラーを捉えることはできません。
 
 ### `static getDerivedStateFromError()` {#static-getderivedstatefromerror}
 ```javascript


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/ja.reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

I found spelling variants in translated documents and fix it.

error boundaryについて表記ゆれを発見したので修正しました（とりあえず翻訳済みドキュメントだけ）。
具体的には以下に従うようにしました。

- https://github.com/reactjs/ja.reactjs.org/pull/81#issuecomment-460994235 `原文での表現にかかわらず error boundary と単数表記`
- https://github.com/reactjs/ja.reactjs.org/pull/81#pullrequestreview-202685756 `タイトル以外の本文中に出てくる "Error Boundary" は小文字に統一（文頭であっても）` 