### PR TITLE
Install textlint-rule-detect-bad-chars

### DIFF
--- a/.textlintrc
+++ b/.textlintrc
@@ -1,5 +1,8 @@
 {
   "rules": {
+    "textlint-rule-detect-bad-chars": {
+
+    },
     "preset-jtf-style": {
       "1.2.1.句点(。)と読点(、)": false,
       "1.2.2.ピリオド(.)とカンマ(,)": false,

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "npm-run-all": "^4.1.5",
     "recursive-readdir": "^2.2.1",
     "textlint": "^11.2.1",
+    "textlint-rule-detect-bad-chars": "^1.0.2",
     "textlint-rule-preset-jtf-style": "^2.3.3",
     "unist-util-map": "^1.0.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -12778,6 +12778,13 @@ text-table@0.2.0, text-table@^0.2.0, text-table@~0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
+textlint-rule-detect-bad-chars@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/textlint-rule-detect-bad-chars/-/textlint-rule-detect-bad-chars-1.0.2.tgz#cd53b23d3f47f9c8b22adbd71c3db7098b655785"
+  integrity sha512-KC7JNBXrFXghQ4blcCMV121jTXTxRomK5jaa+JEN2aOnOQGKB9Bz2dXDFqLbNchVB5zR3+PKVFAkdZEIijU5xA==
+  dependencies:
+    mdast-util-to-string "^1.0.5"
+
 textlint-rule-helper@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/textlint-rule-helper/-/textlint-rule-helper-2.1.1.tgz#d572588685359134bc779939b217e61f087dab0f"


### PR DESCRIPTION
resolve #139 

Chromium 上で入力した場合に稀に挿入される U+0008 を検出、 CI で落とすようにする変更です。

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/ja.reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
