### PR TITLE
Translate DocSearch placeholder

### DIFF
--- a/src/components/LayoutHeader/DocSearch.js
+++ b/src/components/LayoutHeader/DocSearch.js
@@ -97,7 +97,7 @@ class DocSearch extends Component<{}, State> {
           }}
           id="algolia-doc-search"
           type="search"
-          placeholder="Search"
+          placeholder="検索"
           aria-label="Search docs"
         />
       </form>


### PR DESCRIPTION
Fixes #145.

Screenshot:

![image](https://user-images.githubusercontent.com/7779406/54654246-e07ecb80-4b00-11e9-965d-15c77371ba7f.png)
