### PR TITLE
fix "Building Your Own Hooks" translation

### DIFF
--- a/content/docs/hooks-custom.md
+++ b/content/docs/hooks-custom.md
@@ -1,6 +1,6 @@
 ---
 id: hooks-custom
-title: カスタムフックの作成
+title: 独自フックの作成
 permalink: docs/hooks-custom.html
 next: hooks-reference.html
 prev: hooks-rules.html

--- a/content/docs/nav.yml
+++ b/content/docs/nav.yml
@@ -122,7 +122,7 @@
     - id: hooks-rules
       title: フックのルール
     - id: hooks-custom
-      title: カスタムフックの作成
+      title: 独自フックの作成
     - id: hooks-reference
       title: フック API リファレンス
     - id: hooks-faq


### PR DESCRIPTION

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/ja.reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

["Building Your Own Hooks"の翻訳](https://github.com/reactjs/reactjs.org/search?q=%22Building+Your+Own+Hooks%22&unscoped_q=%22Building+Your+Own+Hooks%22)が`カスタムフックの作成`と`独自フックの作成`の2種類存在していました。

リンク先ページの推定が難しく統一した方が良いと考え、より適切な`独自フックの作成`に統一しました。