### PR TITLE
Fix translation in code-splitting doc

### DIFF
--- a/content/docs/code-splitting.md
+++ b/content/docs/code-splitting.md
@@ -100,7 +100,7 @@ Create React App を使用している場合はすでに設定がされている
 
 > 補足:
 >
-> `React.lazy` と Suspense はまだサーバーサイドレンダリングには使用できません。サーバーサイドでレンダリングされたアプリでコード分割をしたい場合には、[Loadable Components](https://github.com/gregberge/loadable-components) の使用をおすすめします。こちらは[サーバーサイドレンダリングでのバンドル分割のための素晴らしいガイド](https://loadable-components.com/docs/server-side-rendering/)も提供していくれているので、参考にしてみてください。
+> `React.lazy` と Suspense はまだサーバーサイドレンダリングには使用できません。サーバーサイドでレンダリングされたアプリでコード分割をしたい場合には、[Loadable Components](https://github.com/gregberge/loadable-components) の使用をおすすめします。[サーバーサイドレンダリングでのバンドル分割のための素晴らしいガイド](https://loadable-components.com/docs/server-side-rendering/)も提供されているので、参考にしてみてください。
 
 `React.lazy` 関数を使用すると、動的インポートを通常のコンポーネントとしてレンダリングすることができます。
 


### PR DESCRIPTION

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/ja.reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

I think that `提供されている` is better than `提供している` for this part because `サーバーサイドレンダリングでのバンドル分割のための素晴らしいガイド` is not provided by reactjs.org.