### PR TITLE
Apply textlint to blog articles after 2020

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "format:examples": "prettier --config examples/.prettierrc --write \"examples/**/*.js\"",
     "generate-ids": "node scripts/generateHeadingIDs.js content",
     "lint": "eslint .",
-    "lint:text": "textlint --rulesdir=./textlint content/{docs,home,tutorial,warnings}/*.md",
+    "lint:text": "textlint --rulesdir=./textlint content/{docs,home,tutorial,warnings}/*.md content/blog/20[2-9]*.md",
     "netlify": "yarn --version && rimraf node_modules && yarn install --frozen-lockfile --check-files && yarn build",
     "nit:source": "prettier --config .prettierrc --list-different \"{gatsby-*.js,{flow-typed,plugins,src}/**/*.js}\"",
     "nit:examples": "prettier --config examples/.prettierrc --list-different \"examples/**/*.js\"",


### PR DESCRIPTION
2020年以降のブログ記事に textlint を適用します。

それより前のブログ記事にも適用しようとすると元の英文にある細かいエラーを見つけてきてしまうので、`blog/20[2-9]*.md` にだけ適用しています。