### PR TITLE
Add delay notice on blog pages

### DIFF
--- a/src/components/MarkdownPage/MarkdownPage.js
+++ b/src/components/MarkdownPage/MarkdownPage.js
@@ -108,6 +108,30 @@ const MarkdownPage = ({
                 </div>
               )}
 
+              {(date || hasAuthors) && (
+                <div
+                  style={{
+                    fontSize: '80%',
+                    marginTop: '2em',
+                    padding: '10px 15px',
+                    lineHeight: '1.5',
+                    background: 'rgba(255,229,100,0.3)',
+                  }}>
+                  日本語版サイト (ja.reactjs.org)
+                  のブログセクションへの投稿掲載には
+                  <a
+                    style={{borderBottom: '1px solid silver'}}
+                    href="https://reactjs.org/blog">
+                    英語版サイト
+                  </a>
+                  と比べてタイムラグがあります。
+                  最新のブログ記事は英語版でご確認ください。
+                  <br />
+                  日本語版サイトでは英語版ブログに定期的に追従しつつ、2020
+                  年以降の投稿を随時翻訳しています。
+                </div>
+              )}
+
               <div css={sharedStyles.articleLayout.content}>
                 <div
                   css={[sharedStyles.markdown]}


### PR DESCRIPTION
ブログ記事ページに以下のようなお知らせを表示します。目的は2つです。

- 英語でもいいので最新記事を読みたいという人が、新着投稿を見逃さないようにする
- 日本語で読みたい人に、しばらく待っていればここで翻訳が読めるよと伝える

今の所全てのブログページ（厳密には author と date がある MarkdownPage）に問答無用で表示するようにしています。2000年以降の記事かどうかで場合分けするともっと素敵だと思いますが `date` が文字列形式だったので一旦諦めました。

----

![image](https://user-images.githubusercontent.com/7779406/90853309-bea00d00-e3b4-11ea-809f-94150061194d.png)