### PR TITLE
CalloutVariantsにおける'wip'と'experimental'のTitleを翻訳

### DIFF
--- a/src/components/MDX/ExpandableCallout.tsx
+++ b/src/components/MDX/ExpandableCallout.tsx
@@ -53,7 +53,7 @@ const variantMap = {
       'linear-gradient(rgba(245, 249, 248, 0), rgba(245, 249, 248, 1)',
   },
   experimental: {
-    title: 'Experimental Feature',
+    title: '実験的機能',
     Icon: IconCanary,
     containerClasses:
       'bg-green-5 dark:bg-green-60 dark:bg-opacity-20 text-primary dark:text-primary-dark text-lg',


### PR DESCRIPTION
<!--

日本語版 (ja.react.dev) リポジトリでのPR/Issueは、日本語版固有の問題
（翻訳や日本語版独自機能に関係するもの）のみ受け付けます。

全言語に関わる問題や改善（英語部分のスペルミス、コードサンプルの修正、ビルドシステム改善等）
については、英語版リポジトリ (https://github.com/reactjs/react.dev)
でPR/Issueを作成してください。

日本語版の作業フローについては以下を参照してください。
https://github.com/reactjs/ja.react.dev/wiki

-->
CalloutVariantsのうち、Titleが未翻訳であるものを翻訳しました。
* 'Experimental Feature' -> '実験的機能'
* 'Under Construction' -> '準備中'

CalloutVariantsの中で他にもTitleが英語のものがありましたが、それぞれ以下の理由で今回は翻訳対象外と判断しました。
* deprecated: `Deprecated`という表現は開発者の中では一般的で、そのままの方が正しくニュアンスが伝わりやすいと思ったため。
* canary: 現状使用されておらずどのような文脈で使用されているのか参考情報がなかく、誤った翻訳を避けたかったため。

<details>
  <summary>表示例</summary>

| タグ | Before | After |
| ---- | ---- | ---- |
| <!-- --> | <!-- --> | <!-- --> |
| experimental | <img width="922" height="431" alt="スクリーンショット 2025-10-20 21 41 59" src="https://github.com/user-attachments/assets/2b73aa60-4231-4c45-917b-b6f7f5bb5a36" /> | <img width="904" height="427" alt="スクリーンショット 2025-10-20 21 42 27" src="https://github.com/user-attachments/assets/3340d885-3bd2-4c10-ada1-84b4aadfbbab" /> |
| wip | <img width="914" height="288" alt="スクリーンショット 2025-10-20 21 41 06" src="https://github.com/user-attachments/assets/4dbc74fd-6eb3-4518-8401-9c34f57ccae1" /> | <img width="907" height="290" alt="スクリーンショット 2025-10-20 21 41 00" src="https://github.com/user-attachments/assets/89633292-b26d-4d64-90e1-8639dcdddacc" /> |

</details>

（何か背景があって未翻訳の状態で置いているようでしたらcloseいただいて大丈夫です🙏 )