### PR TITLE
Translate "Profiler"

### DIFF
--- a/src/content/reference/react/Profiler.md
+++ b/src/content/reference/react/Profiler.md
@@ -89,8 +89,8 @@ React ツリーを `<Profiler>` コンポーネントで囲むことで、その
 
 `<Profiler>` を使うことで測定結果をプログラムで収集することができます。対話型のプロファイラを使いたい場合は、[React Developer Tools](/learn/react-developer-tools) の Profiler タブを試してみてください。これは同様の機能をブラウザの拡張機能として提供します。
 
-Components wrapped in `<Profiler>` will also be marked in the [Component tracks](/reference/dev-tools/react-performance-tracks#components) of React Performance tracks even in profiling builds.
-In development builds, all components are marked in the Components track regardless of whether they're wrapped in `<Profiler>`.
+`<Profiler>` でラップされたコンポーネントは、プロファイリングビルドにおいても React パフォーマンストラックの [コンポーネントトラック](/reference/dev-tools/react-performance-tracks#components) に記録されます。
+開発用ビルドでは、`<Profiler>` でラップされているかどうかにかかわらず、すべてのコンポーネントがコンポーネントトラックに記録されます。
 
 </Note>
 

--- a/src/content/reference/react/Profiler.md
+++ b/src/content/reference/react/Profiler.md
@@ -89,7 +89,7 @@ React ツリーを `<Profiler>` コンポーネントで囲むことで、その
 
 `<Profiler>` を使うことで測定結果をプログラムで収集することができます。対話型のプロファイラを使いたい場合は、[React Developer Tools](/learn/react-developer-tools) の Profiler タブを試してみてください。これは同様の機能をブラウザの拡張機能として提供します。
 
-`<Profiler>` でラップされたコンポーネントは、プロファイリングビルドにおいても React パフォーマンストラックの [コンポーネントトラック](/reference/dev-tools/react-performance-tracks#components) に記録されます。
+`<Profiler>` でラップされたコンポーネントは、プロファイリングビルドにおいても React パフォーマンストラックの[コンポーネントトラック](/reference/dev-tools/react-performance-tracks#components)に記録されます。
 開発用ビルドでは、`<Profiler>` でラップされているかどうかにかかわらず、すべてのコンポーネントがコンポーネントトラックに記録されます。
 
 </Note>


### PR DESCRIPTION
<!--

日本語版 (ja.react.dev) リポジトリでのPR/Issueは、日本語版固有の問題
（翻訳や日本語版独自機能に関係するもの）のみ受け付けます。

全言語に関わる問題や改善（英語部分のスペルミス、コードサンプルの修正、ビルドシステム改善等）
については、英語版リポジトリ (https://github.com/reactjs/react.dev)
でPR/Issueを作成してください。

日本語版の作業フローについては以下を参照してください。
https://github.com/reactjs/ja.react.dev/wiki

-->
Profilerページで、新しく降ってきた英文を翻訳しました。
React Performance trackの[PR](https://github.com/reactjs/ja.react.dev/pull/929)と同様に、
Performance trackをパフォーマンストラックと訳し、
Component trackをコンポーネントトラックとして訳しています。